### PR TITLE
Use encoded < character in pragma regex

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -47,7 +47,7 @@
 			</dict>
 			<dict>
 				<key>match</key>
-				<string>(?<![^\s])##.*?(?=([\.:,\s]))</string>
+				<string>(?&lt;![^\s])##.*?(?=([\.:,\s]))</string>
 				<key>name</key>
 				<string>comment.line.pragma.abap</string>
 			</dict>


### PR DESCRIPTION
👋 from the Linguist community.

If you're not already aware, this grammar is included in [GitHub Linguist](https://github.com/github/linguist) which is used for syntax highlighting ABAP on GitHub.com.

I'm the primary GitHub maintainer and am in the process of creating a new Linguist release (which involved pulling the latest version of this repo) when I noticed that your grammar has changed such that our [grammar compiler](https://github.com/github/linguist/tree/master/tools/grammars) has detected a problem that prevents the grammar from being compiled:

```
Grammar conversion failed. File `Syntaxes/ABAP.tmLanguage` failed to parse: XML syntax error on line 50: invalid <![ sequence
```

This is the regex on line 50:

https://github.com/pvl/abap.tmbundle/blob/221919d83c0342332e4b42c473cfd598ae0565f2/Syntaxes/ABAP.tmLanguage#L50

... introduced in https://github.com/pvl/abap.tmbundle/pull/14.

The problem? `<` is _not_ valid in an XML document and should be encoded.

This PR does just that and encodes `<` to `&lt;`.

If you're quick to merge this, I can ensure it's included in the next release of Linguist and thus GitHub.com.