### PR TITLE
Added basic support for string templates

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -53,6 +53,23 @@
 			</dict>
 			<dict>
 				<key>begin</key>
+				<string>(?<!\\)\|(.*?)</string>
+				<key>end</key>
+				<string>(?<!\\)\|</string>
+				<key>name</key>
+				<string>string.interpolated.abap</string>
+				<key>patterns</key>
+				<array>
+					<dict>
+						<key>match</key>
+						<string>\\\|</string>
+						<key>name</key>
+						<string>constant.character.escape.abap</string>
+					</dict>
+				</array>
+			</dict>
+			<dict>
+				<key>begin</key>
 				<string>'</string>
 				<key>end</key>
 				<string>'</string>

--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -53,9 +53,9 @@
 			</dict>
 			<dict>
 				<key>begin</key>
-				<string>(?<!\\)\|(.*?)</string>
+				<string>(?&lt;!\\)\|(.*?)</string>
 				<key>end</key>
-				<string>(?<!\\)\|</string>
+				<string>(?&lt;!\\)\|</string>
 				<key>name</key>
 				<string>string.interpolated.abap</string>
 				<key>patterns</key>


### PR DESCRIPTION
Currently does not support special highlighting of { placeholders }, but consides escaped |. Fixes issue with ' and ` breaking highlighting, as they are now considered part of the interpolated string.

![code_2018-09-30_17-55-35](https://user-images.githubusercontent.com/5097067/46259497-83537700-c4da-11e8-8e85-fda0641c64cd.png)
