### PR TITLE
Fix for data, value at the end of method names

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -316,7 +316,7 @@
 			<key>keywords_followed_by_braces</key>
 			<dict>
 				<key>match</key>
-				<string>(?ix)\s*(data|value|field-symbol)(?=\()</string>
+				<string>(?ix)\b(data|value|field-symbol)(?=\()</string>
 				<key>name</key>
 				<string>keyword.control.simple.abap</string>
 			</dict>


### PR DESCRIPTION
I noticed that now if there is a method name ending with data or value, part of its method call will get highlighted as it contains DATA( or VALUE(.

`/s*` was there to cover the case where the code is at the beginning of a line, but this also works with \b.

![code_2018-10-01_10-07-24](https://user-images.githubusercontent.com/5097067/46277069-577bd400-c562-11e8-87ea-01f6a2df5f1e.png)
![code_2018-10-01_10-09-24](https://user-images.githubusercontent.com/5097067/46277105-74b0a280-c562-11e8-97f8-79df9b26aad5.png)

