### PR TITLE
Added support for string literals

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -87,6 +87,23 @@
 			</dict>
 			<dict>
 				<key>begin</key>
+				<string>`</string>
+				<key>end</key>
+				<string>`</string>
+				<key>name</key>
+				<string>string.quoted.single.abap</string>
+				<key>patterns</key>
+				<array>
+					<dict>
+						<key>match</key>
+						<string>``</string>
+						<key>name</key>
+						<string>constant.character.escape.abap</string>
+					</dict>
+				</array>
+			</dict>
+			<dict>
+				<key>begin</key>
 				<string>(?i)^\s*(class|method|form)\s+(?=[a-z_][a-z_0-9])</string>
 				<key>beginCaptures</key>
 				<dict>


### PR DESCRIPTION
They are the same as character literals, only with a different escape character.

![code_2018-10-01_14-24-06](https://user-images.githubusercontent.com/5097067/46288415-d7fffc00-c585-11e8-8f28-f3ea160da936.png)

![code_2018-10-01_14-25-49](https://user-images.githubusercontent.com/5097067/46288430-ea7a3580-c585-11e8-89ce-063229143a3c.png)
