### PR TITLE
Fixed issues related to whitespace in matches

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -291,10 +291,6 @@
 					</dict>
 					<dict>
 						<key>include</key>
-						<string>#short_keywords</string>
-					</dict>
-					<dict>
-						<key>include</key>
 						<string>#keywords_followed_by_braces</string>
 					</dict>
 				</array>
@@ -317,8 +313,8 @@
 			<dict>
 				<key>match</key>
 				<string>(?ix)(&lt;=^|\s)(
-	        abstract|alias|aliases|append|appending|ascending|assert|assign|assigning|
-	        back|begin|binary|bound|byte|
+	        abstract|add|alias|aliases|all|append|appending|ascending|as|assert|assign|assigning|
+	        back|begin|binary|bound|by|byte|
 	        call|cast|changing|check|clear|close|cnt|collect|commit|character|
 	        corresponding|communication|component|compute|concatenate|condense|constants|
 	        controls|convert|create|currency|
@@ -329,20 +325,21 @@
 	        endprovide|endselect|endtry|endwhile|event|events|exec|exit|export|
 	        exporting|extract|exception|exceptions|
 	        first|fetch|fields|format|free|from|function|find|for|
-	        generate|
+	        generate|get|
 	        hide|
 	        import|importing|index|infotypes|initial|initialization|
-	        interface|interfaces|input|insert|into|
+	        is|in|interface|interfaces|input|insert|into|
 			key|
 	        leave|like|line|load|local|length|left|leading|lower|
 	        method|message|methods|modify|module|move|multiply|match|
-	        occurrence|object|obligatory|overlay|optional|others|occurrences|occurs|offset|
-	        pack|parameters|perform|position|private|program|protected|provide|public|
+			no|
+	        occurrence|object|obligatory|of|overlay|optional|others|occurrences|occurs|offset|
+	        pack|parameters|perform|position|private|program|protected|provide|public|put|
 	        radiobutton|raising|ranges|receive|receiving|redefinition|reference|refresh|regex|reject|results|
-	        replace|report|reserve|restore|return|returning|rollback|read|
-	        scan|screen|scroll|search|select|separated|shift|single|skip|sort|sorted|split|standard|starting|
+	        ref|replace|report|reserve|restore|return|returning|rollback|read|
+	        scan|screen|scroll|search|select|separated|set|shift|single|skip|sort|sorted|split|standard|starting|sum|
 	        statics|step|stop|structure|submatches|submit|subtract|summary|suppress|section|
-	        tables|table|testing|then|times|titlebar|transfer|transformation|translate|transporting|types|type|
+	        tables|table|testing|then|times|titlebar|to|transfer|transformation|translate|transporting|types|type|
 	        unassign|uline|unpack|update|using|
 	        value|
 	        when|while|window|write|where|with|work
@@ -401,13 +398,6 @@
 				<string>\s(&amp;&amp;|\?\=)\s</string>
 				<key>name</key>
 				<string>keyword.operator.other.abap</string>
-			</dict>
-			<key>short_keywords</key>
-			<dict>
-				<key>match</key>
-				<string>(?i)\s(add|all|as|by|in|get|no|of|put|ref|set|sum|to)(?=\s|\.|:)</string>
-				<key>name</key>
-				<string>keyword.control.short.abap</string>
 			</dict>
 			<key>string_operators</key>
 			<dict>

--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -298,7 +298,7 @@
 			<key>logical_operator</key>
 			<dict>
 				<key>match</key>
-				<string>(?i)(&lt;=\s)(not|or|and)(?=\s)</string>
+				<string>(?i)(?&lt;=\s)(not|or|and)(?=\s)</string>
 				<key>name</key>
 				<string>keyword.operator.arithmetic.abap</string>
 			</dict>
@@ -312,7 +312,7 @@
 			<key>main_keywords</key>
 			<dict>
 				<key>match</key>
-				<string>(?ix)(&lt;=^|\s)(
+				<string>(?ix)(?&lt;=^|\s)(
 	        abstract|add|alias|aliases|all|append|appending|ascending|as|assert|assign|assigning|
 	        back|begin|binary|bound|by|byte|
 	        call|cast|changing|check|clear|close|cnt|collect|commit|character|

--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -185,7 +185,7 @@
 			<key>abap_constants</key>
 			<dict>
 				<key>match</key>
-				<string>(?ix)\s(initial|null|space|abap_true|abap_false|table_line)\s</string>
+				<string>(?ix)(?&lt;=\s)(initial|null|space|abap_true|abap_false|table_line)(?=\s|\.|,)</string>
 				<key>name</key>
 				<string>constant.language.abap</string>
 			</dict>
@@ -199,14 +199,14 @@
 			<key>arithmetic_operator</key>
 			<dict>
 				<key>match</key>
-				<string>\s(\+|\-|\*|\*\*|/|%)\s</string>
+				<string>(?&lt;=\s)(\+|\-|\*|\*\*|/|%)(?=\s)</string>
 				<key>name</key>
 				<string>keyword.operator.arithmetic.abap</string>
 			</dict>
 			<key>comparison_operator</key>
 			<dict>
 				<key>match</key>
-				<string>(?i)\s(&lt;|&gt;|&lt;\=|&gt;\=|\=|&lt;&gt;|eq|ne|lt|le|gt|ge|cs)\s</string>
+				<string>(?i)(?&lt;=\s)(&lt;|&gt;|&lt;\=|&gt;\=|\=|&lt;&gt;|eq|ne|lt|le|gt|ge|cs|cp)(?=\s)</string>
 				<key>name</key>
 				<string>keyword.operator.comparison.abap</string>
 			</dict>
@@ -302,7 +302,7 @@
 			<key>logical_operator</key>
 			<dict>
 				<key>match</key>
-				<string>(?i)\s(is|not|or|and)\s</string>
+				<string>(?i)(&lt;=\s)(not|or|and)(?=\s)</string>
 				<key>name</key>
 				<string>keyword.operator.arithmetic.abap</string>
 			</dict>
@@ -316,7 +316,7 @@
 			<key>main_keywords</key>
 			<dict>
 				<key>match</key>
-				<string>(?ix)(^|\s)(
+				<string>(?ix)(&lt;=^|\s)(
 	        abstract|alias|aliases|append|appending|ascending|assert|assign|assigning|
 	        back|begin|binary|bound|byte|
 	        call|cast|changing|check|clear|close|cnt|collect|commit|character|


### PR DESCRIPTION
Whitespace should not be part of a token match - this causes issues because the next token expects to start with whitespace, which was consumed by the previous token and is therefore not highlighted. 
I changed instances of \s to lookaheads or lookbehinds which don't consume characters. There's probably a few more places where this needs to be done, but I don't want any unintended side effects.

`IS` was moved from logical operators to regular keywords to prevent `IS INITIAL` and similar from having different colors.

All short keywords were moved to regular keywords because:
- They don't require special rules, so this is just an extra place to maintain the beginning/end part of the regex
- Keyword.control.short is not a standard scope name, meaning they will be colored the same anyway

![code_2018-10-10_15-15-17](https://user-images.githubusercontent.com/5097067/46738827-70416380-cc9f-11e8-8776-91b05057fdc7.png)
```abap
DATA(abc) = abap_false.
DATA(sum) = 2 + 3.
DATA(db_row) = SELECT * FROM itab.
IF abc IS BOUND.
    IF abap_true = abap_false.
        DATA: var1 type abap_bool value abap_true,
              var2 type abap_bool value abap_false.
    ENDIF.
ENDIF.
```

This should resolve the remaining issues in #3.