### PR TITLE
Higlighting for field symbols

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -157,7 +157,7 @@
 				<key>match</key>
 				<string>(?i)(&lt;[A-Za-z_][A-Za-z0-9_]*&gt;)</string>
 				<key>name</key>
-				<string>meta.variable.other.field.symbol.abap</string>
+				<string>variable.other.field.symbol.abap</string>
 			</dict>
 			<dict>
 				<key>include</key>


### PR DESCRIPTION
By correcting the scope name we can get free highlighting for field symbols.

![code_2018-10-15_18-42-35](https://user-images.githubusercontent.com/5097067/46965153-52fb0380-d0aa-11e8-8f45-7798d0c7fce1.png)
