### PR TITLE
Highlighting for string template placeholders

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -53,13 +53,41 @@
 			</dict>
 			<dict>
 				<key>begin</key>
-				<string>(?&lt;!\\)\|(.*?)</string>
+				<string>(?&lt;!\\)(\|)(.*?)</string>
 				<key>end</key>
-				<string>(?&lt;!\\)\|</string>
+				<string>(?&lt;!\\)(\|)</string>
 				<key>name</key>
 				<string>string.interpolated.abap</string>
+				<key>beginCaptures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>constant.character.escape.abap</string>
+					</dict>
+				</dict>
+				<key>endCaptures</key>
+				<dict>
+					<key>1</key>
+					<dict>
+						<key>name</key>
+						<string>constant.character.escape.abap</string>
+					</dict>
+				</dict>
 				<key>patterns</key>
 				<array>
+					<dict>
+						<key>match</key>
+						<string>({ )|( })</string>
+						<key>name</key>
+						<string>constant.character.escape</string>
+					</dict>
+					<dict>
+						<key>match</key>
+						<string>(?&lt;={ ).*?(?= })</string>
+						<key>name</key>
+						<string>variable.other.abap</string>
+					</dict>
 					<dict>
 						<key>match</key>
 						<string>\\\|</string>


### PR DESCRIPTION
A lot better than the current version #30 , but treats the whole placeholder content as one token. This might resolve itself once the grammar can recognize methods.

I misused the scope names (constant.character.escape) a bit to get better colors for punctuation, but this shouldn't matter as all the scopes are used for is highlighting anyway.

![code_2018-10-17_17-01-03](https://user-images.githubusercontent.com/5097067/47095914-72229e00-d22e-11e8-98da-c5168d7ec748.png)
