### PR TITLE
Fixed class names ending with multiple numbers

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -138,7 +138,7 @@
 			</dict>
 			<dict>
 				<key>begin</key>
-				<string>(?i)^\s*(class|method|form)\s([a-z_]+[a-z_0-9])</string>
+				<string>(?i)^\s*(class|method|form)\s([a-z_][a-z_0-9]*)</string>
 				<key>beginCaptures</key>
 				<dict>
 					<key>1</key>


### PR DESCRIPTION
Only the first number was highlighted:
![image](https://user-images.githubusercontent.com/5097067/47778962-499fa700-dcf8-11e8-8cc7-f2fda7d1cf14.png)

<img width="163" alt="code_2018-10-31_10-30-05" src="https://user-images.githubusercontent.com/5097067/47778966-4c9a9780-dcf8-11e8-81ff-92fca40f432a.png">
