### PR TITLE
Highlight me, super, class sections + small fixes

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -58,6 +58,12 @@
 				<string>constant.numeric.abap</string>
 			</dict>
 			<dict>
+				<key>match</key>
+				<string>(?ix)(^|\s+)((PUBLIC|PRIVATE|PROTECTED)\sSECTION)(?=\s+|:|\.)</string>
+				<key>name</key>
+				<string>storage.modifier.class.abap</string>
+			</dict>
+			<dict>
 				<key>begin</key>
 				<string>(?&lt;!\\)(\|)(.*?)</string>
 				<key>end</key>
@@ -307,7 +313,7 @@
 				<array>
 					<dict>
 						<key>match</key>
-						<string>(?ix)(?&lt;=^|\s)(USING|TABLES|CHANGING)(?=\s+|\.)</string>
+						<string>(?ix)(?&lt;=^|\s)(USING|TABLES|CHANGING|RAISING)(?=\s+|\.)</string>
 						<key>name</key>
 						<string>storage.modifier.form.abap</string>
 					</dict>
@@ -339,6 +345,10 @@
 			</dict>
 			<dict>
 				<key>include</key>
+				<string>#reserved_names</string>
+			</dict>
+			<dict>
+				<key>include</key>
 				<string>#operators</string>
 			</dict>
 			<dict>
@@ -363,13 +373,20 @@
 				<key>name</key>
 				<string>constant.language.abap</string>
 			</dict>
+			<key>reserved_names</key>
+			<dict>
+				<key>match</key>
+				<string>(?ix)(?&lt;=\s)(me|super)(?=\s|\.|,|-&gt;)</string>
+				<key>name</key>
+				<string>constant.language.abap</string>
+			</dict>
 			<key>abaptypes</key>
 			<dict>
 			<key>patterns</key>
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(?ix)\s(abap_bool|data|string|xstring|any|clike|csequence|numeric|xsequence|c|n|i|p|f|d|t|x)(?=\s|\.|,)</string>
+					<string>(?ix)\s(abap_bool|string|xstring|any|clike|csequence|numeric|xsequence|c|n|i|p|f|d|t|x)(?=\s|\.|,)</string>
 					<key>name</key>
 					<string>support.type.abap</string>	
 				</dict>


### PR DESCRIPTION
- me, super
- changed coloring for class sections
- Added RAISING in form declarations
- Coloring data as a type (ref to data) was overeager as it is a very common word. It is now again just a keyword

Resolves #45, #28

![Code_Csm8YyIiMM](https://user-images.githubusercontent.com/5097067/54477167-72d35680-4805-11e9-96f2-2f61b1146b16.png)
