### PR TITLE
Improve highlighting for variables in write positions

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -53,7 +53,7 @@
 			</dict>
 			<dict>
 				<key>match</key>
-				<string>(?i)(?&lt;=\s)([a-z_/][a-z_0-9/]*)(?=\s+=\s+)</string>
+				<string>(?i)(?&lt;=(?:^|\s|~|-&gt;|-|=&gt;))([a-z_/][a-z_0-9/]*)(?=\s+(?:=|\+=|-=|\*=|\/=|&amp;&amp;=)\s+)</string>
 				<key>name</key>
 				<string>variable.other.abap</string>
 			</dict>


### PR DESCRIPTION
```abap
    variable = 5. " currently only this works

    class=>member = 3.
    instance->member = 5.
    structure-component = 5.
    interface~member = 5.

    variable += 4.
    variable -= 4.
    variable *= 4.
    variable /= 4.
    variable &&= 4.
```

Added support for additional cases:

![](https://user-images.githubusercontent.com/5097067/102388309-dd648800-3fd1-11eb-89b1-47dca163bc33.png)