### PR TITLE
Fix escaping in interpolated strings

### DIFF
--- a/Syntaxes/ABAP.tmLanguage
+++ b/Syntaxes/ABAP.tmLanguage
@@ -73,7 +73,7 @@
 				<key>begin</key>
 				<string>(?&lt;!\\)(\|)(.*?)</string>
 				<key>end</key>
-				<string>(?&lt;!\\)(\|)</string>
+				<string>(?&lt;!\\)(\||(\\\\\|))</string>
 				<key>name</key>
 				<string>string.interpolated.abap</string>
 				<key>beginCaptures</key>


### PR DESCRIPTION
regex by https://github.com/marcellourbani

![image](https://user-images.githubusercontent.com/5097067/136245362-bf52ee66-ffe7-408d-8d40-07a4f60b328c.png)
![image](https://user-images.githubusercontent.com/5097067/136245340-319c2ab8-0261-4243-881f-e0afca9a0af1.png)
